### PR TITLE
feat: add wish stats functionality between NGU and GO

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ This sends current hack stats from NGU to GO for the `Hacks` tab.
 
 This sends the hack goals from GO to NGU which sets hack targets.
 
+## sending wish stats from NGU to GO
+`javascript:fetch("http://localhost:8088/ngu/NGU2GO/wishstats").then(s=>s.json()).then(s=>{Object.assign(appState.wishstats,s),appHandlers.handleSettings("wishstats",nguStats)});`
+
+This sends current wish stats from NGU to GO for the `Wishes` tab.
+
 # Twitch Integration
 
 ## setup

--- a/source/WebService/GO/NGU2GO.cs
+++ b/source/WebService/GO/NGU2GO.cs
@@ -38,6 +38,11 @@ namespace jshepler.ngu.mods.WebService.GO
                     context.Response.SendResponse(HttpStatusCode.OK, json, ContentTypes.JSON);
                     return () => Plugin.ShowOverrideNotification("NGU2GO: equipped");
 
+                case "wishstats":
+                    json = Wishes.BuildWishStats();
+                    context.Response.SendResponse(HttpStatusCode.OK, json, ContentTypes.JSON);
+                    return () => Plugin.ShowOverrideNotification("NGU2GO: wish stats");
+
                 default:
                     context.Response.SendResponse(HttpStatusCode.BadRequest, $"unknown resource: {resource}");
                     return () => Plugin.ShowOverrideNotification($"NGU2GO: unknown resource: {resource}");

--- a/source/WebService/GO/Wishes.cs
+++ b/source/WebService/GO/Wishes.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using SimpleJSON;
+
+namespace jshepler.ngu.mods.WebService.GO
+{
+    internal class Wishes
+    {
+        private static Action _uiUpdateAction;
+
+        static Wishes()
+        {
+            Plugin.OnUpdate += (o, e) =>
+            {
+                if (_uiUpdateAction != null)
+                {
+                    _uiUpdateAction();
+                    _uiUpdateAction = null;
+                }
+            };
+        }
+
+        internal static string BuildWishStats()
+        {
+            var character = Plugin.Character;
+
+            var root = new JSONObject();
+            root.Add("blueHeart", character.inventory.itemList.itemMaxxed[(int)GameData.Items.Heart_Blue]);
+            root.Add("epow", character.totalEnergyPower());
+            root.Add("ecap", character.totalCapEnergy());
+            root.Add("mpow", character.totalMagicPower());
+            root.Add("mcap", character.totalCapMagic());
+            root.Add("rpow", character.totalRes3Power());
+            root.Add("rcap", character.totalCapRes3());
+            root.Add("wishspeed", character.wishesController.totalWishSpeedBonuses());
+
+            return root.ToString();
+        }
+    }
+}

--- a/source/WebService/GO/bookmarklets.js
+++ b/source/WebService/GO/bookmarklets.js
@@ -92,3 +92,16 @@ function go2ngu_hacks2() {
         body: JSON.stringify(appState.hackstats.hacks.map(h => h.goal))
     });
 }
+
+
+// NGU2GO/wishstats
+// javascript:fetch("http://localhost:8088/ngu/NGU2GO/wishstats").then(s=>s.json()).then(s=>{Object.assign(appState.wishstats,s),appHandlers.handleSettings("wishstats",nguStats)});
+function ngu2go_wishstats() {
+    fetch("http://localhost:8088/ngu/NGU2GO/wishstats")
+        .then(resp => resp.json())
+        .then(data => {
+            let wishStats = appState.wishstats;
+            Object.assign(wishStats, data);
+            appHandlers.handleSettings("wishstats", nguStats);
+        });
+}


### PR DESCRIPTION
This pull request introduces functionality to send wish stats from NGU to GO, similar to the existing feature for hack stats. The main changes include updates to the documentation, the addition of a new case in the request handler, and the implementation of the wish stats feature.

New functionality for wish stats:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82-R86): Added documentation for sending wish stats from NGU to GO.
* [`source/WebService/GO/NGU2GO.cs`](diffhunk://#diff-1aac7767f4975e1b535ab24a187f742cae715e92dd2e80b97e319d9725e4b4e6R42-R46): Added a new case for "wishstats" in the `HandleRequest` method to handle the new feature.
* [`source/WebService/GO/Wishes.cs`](diffhunk://#diff-1e4aab5f12f1585f3277284055f9a7afefd14038f23011cc83308f59129de6c8R1-R39): Implemented the `Wishes` class with a method `BuildWishStats` to gather and return wish stats as a JSON object.

Additional changes:

* [`source/WebService/GO/bookmarklets.js`](diffhunk://#diff-42327975cac77c7842ab2d7ce539c641bfa0e3655f208b2917d80b93df7e92e6R95-R107): Added a new function `ngu2go_wishstats` to fetch and handle wish stats from the server.